### PR TITLE
sdk: export assetbundle with lowercase filename

### DIFF
--- a/UnitySDK/ValheimPlayerModelsSDK/Editor/ValheimAvatarDescriptorInspector.cs
+++ b/UnitySDK/ValheimPlayerModelsSDK/Editor/ValheimAvatarDescriptorInspector.cs
@@ -201,12 +201,15 @@ public class ValheimAvatarDescriptorInspector : Editor
 
         if (GUILayout.Button("Export"))
         {
-            string path = EditorUtility.SaveFilePanel("Save object file", "", descriptor.avatarName + ".valavtr", "valavtr");
+            string path = EditorUtility.SaveFilePanel("Save object file", "", descriptor.avatarName.ToLower() + ".valavtr", "valavtr");
 
             if (path != "")
             {
                 string fileName = Path.GetFileName(path);
                 string folderPath = Path.GetDirectoryName(path);
+                // ensure filename is lowercase
+                fileName = fileName.ToLower();
+                path = Path.Join(folderPath, fileName);
 
                 Selection.activeObject = descriptor.gameObject;
                 EditorUtility.SetDirty(descriptor);


### PR DESCRIPTION
This fixes exporting avatars where the user chose a mixed-case character or file name on a case-sensitive filesystem.

From the Unity docs[1]:

> To avoid surprises we recommend choosing a lowercase name for your AssetBundle.

[1]: https://docs.unity3d.com/6000.3/Documentation/ScriptReference/AssetBundleBuild-assetBundleName.html